### PR TITLE
Remove need for multirun, add docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,11 +89,11 @@ jobs:
       - run:
           name: Run Non-coverage Tests
           # This assumes pytest is installed via the install-package step above
-          command: bazel test //sematic/... --test_output=all
+          command: PYTHONUNBUFFERED=1 bazel test //sematic/... --test_output=all
       - run:
           name: Run Coverage Tests
           # This assumes pytest is installed via the install-package step above
-          command: bazel coverage //sematic/... --test_output=all --combined_report=lcov --test_tag_filters=cov
+          command: PYTHONUNBUFFERED=1 bazel coverage //sematic/... --test_output=all --combined_report=lcov --test_tag_filters=cov
       - run:
           name: Link to codecov output
           command: ln -s $(bazel info output_path)/_coverage/_coverage_report.dat coverage.dat

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -146,20 +146,6 @@ load(
 
 _py_image_repos()
 
-## MULTIRUN RULES
-
-
-git_repository(
-    name = "com_github_ash2k_bazel_tools",
-    commit = "8ec69576f63c254a089a63ebf7385e7ee1a871e9",
-    remote = "https://github.com/ash2k/bazel-tools.git",
-)
-
-load("@com_github_ash2k_bazel_tools//multirun:deps.bzl", "multirun_dependencies")
-
-multirun_dependencies()
-
-
 load("@sematic//bazel:pipeline.bzl", "base_images")
 
 base_images()

--- a/bazel/pipeline.bzl
+++ b/bazel/pipeline.bzl
@@ -145,7 +145,9 @@ def base_images():
 
 def _sematic_push_and_run(ctx):
     script = ctx.actions.declare_file("{0}.sh".format(ctx.label.name))
-    content_generators = [
+
+    # the script it simple enough it doesn't really merit a template & template expansion
+    script_lines = [
         "#!/bin/sh",
 
         # A common pattern is to have the bazel binary checked into the root of the
@@ -162,8 +164,8 @@ def _sematic_push_and_run(ctx):
         "fi",
     ]
     command = "touch {}".format(script.path)
-    for content_generator in content_generators:
-        command += " && echo '{}' >> {}".format(content_generator, script.path)
+    for script_line in script_lines:
+        command += " && echo '{}' >> {}".format(script_line, script.path)
     
     command = "{}".format(command)
     ctx.actions.run_shell(

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
 * [Type support](type-support.md)
 * [Future algebra](future-algebra.md)
 * [Deploy Sematic](deploy.md)
+* [Container images](container-images.md)
 * [Artifacts](artifacts.md)
 * [Glossary](glossary.md)
 

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -111,11 +111,18 @@ sematic_pipeline(
 With that, you're done! Assuming the target for your launch script was
 `//my_repo/my_package:my_target`, you now have the following targets available:
 
-- `//my_repo/my_package:my_target`: still runs your target, but builds a Docker
-image with your code and its dependencies first
+- `//my_repo/my_package:my_target`: still runs your target, but builds and pushes
+a Docker image with your code and its dependencies first. Is essentially an alias
+for `bazel run //my_repo/my_package:my_target_push` followed by ``
+- `bazel run //my_repo/my_package:my_target_binary`: runs your target, building
+the image, but NOT pushing it. Generally this is only useful when combined with
+`bazel run //my_repo/my_package:my_target_push`.
 - `//my_repo/my_package:my_target_local`: runs your target WITHOUT building and
 pushing the image. This can help for local development when you don't want the
-overhead of waiting for the build & push.
+overhead of waiting for the build & push. Differs from `:my_target_binary` in
+that Sematic will not know how to reference a container image when executed this
+way, and thus won't work for remote execution even when combined with a
+`:my_target_push`.
 - `//my_repo/my_package:my_target_image`: builds the image, but doesn't push it
 or run your script
 - `//my_repo/my_package:my_target_push`: builds and pushes the image, but

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -112,11 +112,12 @@ With that, you're done! Assuming the target for your launch script was
 `//my_repo/my_package:my_target`, you now have the following targets available:
 
 - `//my_repo/my_package:my_target`: still runs your target, but builds and pushes
-a Docker image with your code and its dependencies first. Is essentially an alias
-for `bazel run //my_repo/my_package:my_target_push` followed by ``
-- `bazel run //my_repo/my_package:my_target_binary`: runs your target, building
-the image, but NOT pushing it. Generally this is only useful when combined with
-`bazel run //my_repo/my_package:my_target_push`.
+a Docker image with your code and its dependencies first. It's essentially an
+alias for `bazel run //my_repo/my_package:my_target_push` followed by
+`bazel run //my_repo/my_package:my_target_binary`.
+- `bazel run //my_repo/my_package:my_target_binary`: builds the image, does NOT
+push it, and executes your launch script. Generally this is only useful when
+combined with `bazel run //my_repo/my_package:my_target_push`.
 - `//my_repo/my_package:my_target_local`: runs your target WITHOUT building and
 pushing the image. This can help for local development when you don't want the
 overhead of waiting for the build & push. Differs from `:my_target_binary` in

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -6,12 +6,12 @@ and your pipelines run locally.
 Here is how to deploy Sematic to take full advantage of your cloud resources.
 Before you start, you will need to decide how you wish to use Sematic.
 
-* Option 1 is to use Sematic to track and share your pipeline executions, but
-still have the pipelines execute locally. This setup is simpler, but less
-powerful.
-* Option 2 is to deploy Sematic on Kubernetes, where the pipelines
-can have access to more powerful compute by executing in the cloud. This
-setup is a little more complex and has more pre-requisites.
+- Option 1 is to use Sematic to track and share your pipeline executions, but
+  still have the pipelines execute locally. This setup is simpler, but less
+  powerful.
+- Option 2 is to deploy Sematic on Kubernetes, where the pipelines
+  can have access to more powerful compute by executing in the cloud. This
+  setup is a little more complex and has more pre-requisites.
 
 ## Deployment Option 1: Shared Metadata Server
 
@@ -25,9 +25,9 @@ Your pipelines will still execute locally.
 
 Prerequisites:
 
-* A remote instance into which you can SSH
-* A Postgres database
-* [Install Docker](https://docs.docker.com/engine/install/) onto your remote instance
+- A remote instance into which you can SSH
+- A Postgres database
+- [Install Docker](https://docs.docker.com/engine/install/) onto your remote instance
 
 Then, SSH into your remote server:
 
@@ -72,11 +72,11 @@ behavior for your deployed app.
 If you don't pass any of them, your app will be available publicly and users will not need to
 authenticate to use it. Everyone will be the "Anonymous" user.
 
-* `SEMATIC_AUTHENTICATE` activates authentication. Users will need to sign in to user the web app,
+- `SEMATIC_AUTHENTICATE` activates authentication. Users will need to sign in to user the web app,
   and will need to set an API key in their local settings in order to submit jobs.
-* `GOOGLE_OAUTH_CLIENT_ID` is the client ID of your Google OAuth App. We will support more OAuth
+- `GOOGLE_OAUTH_CLIENT_ID` is the client ID of your Google OAuth App. We will support more OAuth
   providers int he future.
-* `SEMATIC_AUTHORIZED_EMAIL_DOMAIN` denies access to users whose email is not of said domain.
+- `SEMATIC_AUTHORIZED_EMAIL_DOMAIN` denies access to users whose email is not of said domain.
 
 ##### SSL
 
@@ -87,6 +87,7 @@ private key files are accessible within the container (e.g. place them in the
 `~/.sematic` directory). Also make sure to add `-p 443:443` to the forwarded ports.
 
 ## Deployment Option 2: Sematic with Cloud Execution
+
 If you wish to not only use your Sematic deployment to share the results
 of pipeline executions, but also to actually execute the pipelines, you
 will need to deploy it on Kubernetes.
@@ -95,12 +96,12 @@ will need to deploy it on Kubernetes.
 
 Prerequisites:
 
-* A Kubernetes cluster running Kubernetes >=1.21
-* A Postgres database
-* [Helm](https://helm.sh/docs/intro/install/#helm) &
+- A Kubernetes cluster running Kubernetes >=1.21
+- A Postgres database
+- [Helm](https://helm.sh/docs/intro/install/#helm) &
   [kubectl](https://kubernetes.io/docs/tasks/tools/) installed and
   able to access your Kubernetes cluster
-* Ingress configured on your cluster that allows accessing services deployed on it
+- Ingress configured on your cluster that allows accessing services deployed on it
 
 Run the following command to deploy a Kubernetes secret containing the database URL:
 
@@ -134,14 +135,14 @@ Once you have set all the values, deploy using `helm install sematic ./` from th
 In the `values.yaml` file above, three settings dictate the
 authentication behavior for your deployed app.
 
-* `auth.enabled` activates authentication. Users will need to sign in to
+- `auth.enabled` activates authentication. Users will need to sign in to
   user the web app, and will need to set an API key in their local settings in
   order to submit jobs.
 
-* `auth.google_oauth_client_id` is the client ID of your Google OAuth App.
+- `auth.google_oauth_client_id` is the client ID of your Google OAuth App.
   We will support more OAuth providers in the future.
 
-* `auth.authorized_email_domain` denies access to users whose email is not of
+- `auth.authorized_email_domain` denies access to users whose email is not of
   said domain.
 
 ##### SSL
@@ -152,6 +153,7 @@ that points to the service (named `sematic-service`) deployed by the helm chart,
 and set up your ingress to use SSL.
 
 ## Using your deployment
+
 ### Run pipelines against the deployed API
 
 At this point you should be able to run pipelines that are tracked by Sematic.
@@ -178,15 +180,26 @@ focuses support on **Amazon Web Services**. Other providers to follow soon.
 
 Before you proceed, the following must be true:
 
-* The Sematic web app is deployed. See
+- The Sematic web app is deployed. See
   [Deploy the web app](#deployment-option-2-sematic-with-cloud-execution).
 
-* You have an S3 bucket and you and nodes in your Kubernetes cluster have read
+- You have an S3 bucket and you and nodes in your Kubernetes cluster have read
   and write permissions to it.
 
-* You have a container registry (e.g. AWS Elastic Container Registry) and you
+- You have a container registry (e.g. AWS Elastic Container Registry) and you
   have write access, and nodes in yout Kubernetes cluster have read access to
   it.
+
+- You have `sematic_pipeline` bazel targets defined as described in
+  [Container Images](./container-images.md). This will enable `bazel run` commands
+  to execute the launch script to start your cloud jobs.
+
+{% hint style="warning" %}
+
+Sematic plans to support other ways to produce container images besides
+bazel, but for now it is required for cloud execution.
+
+{% endhint %}
 
 When you are set, the following settings should be visible to Sematic
 
@@ -203,11 +216,10 @@ SEMATIC_API_ADDRESS: <web-app-server-address>
 If you have chosen to deploy Sematic in such a way that users of Sematic
 will use a different URL for the server from what should be used for
 jobs on your Kubernetes cluster (e.g. users access via a reverse proxy
-that's not needed on Kubernetes), you may also need to set 
+that's not needed on Kubernetes), you may also need to set
 `SEMATIC_WORKER_API_ADDRESS`. That will set the URL to be used from
 Kubernetes, while `SEMATIC_API_ADDRESS` will be used from your machine.
 {% endhint %}
-
 
 #### Cloud storage bucket
 

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -66,7 +66,8 @@ dedicated resources (e.g. GPUs).
 
 {% hint style="info" %}
 
-**Prerequisite:** To learn how to deploy Sematic in your cloud, read [Deploy Sematic](./deploy.md).
+**Prerequisite:** To learn how to deploy Sematic in your cloud, read
+[Deploy Sematic](./deploy.md) and [Container images](./container-images.md).
 
 {% endhint %}
 

--- a/sematic/BUILD
+++ b/sematic/BUILD
@@ -68,6 +68,22 @@ sematic_py_lib(
 )
 
 sematic_py_lib(
+    name = "log_reader",
+    srcs = ["log_reader.py"],
+    deps = [
+        "//sematic:storage",
+        "//sematic:abstract_future",
+        "//sematic/db:queries",
+        "//sematic/resolvers:cloud_resolver",
+        "//sematic/scheduling:external_job",
+    ],
+    pip_deps = [
+        "requests",
+    ]
+)
+
+
+sematic_py_lib(
     name = "client",
     srcs = ["client.py"],
     deps = [

--- a/sematic/api/endpoints/BUILD
+++ b/sematic/api/endpoints/BUILD
@@ -11,6 +11,7 @@ sematic_py_lib(
         "//sematic/db/models:edge",
         "//sematic/db/models:run",
         "//sematic/db/models:user",
+        "//sematic:log_reader",
         "//sematic/scheduling:job_scheduler",
     ],
     pip_deps = [

--- a/sematic/api/endpoints/tests/test_runs.py
+++ b/sematic/api/endpoints/tests/test_runs.py
@@ -2,6 +2,7 @@
 import json
 import typing
 import uuid
+from dataclasses import asdict
 from unittest import mock
 
 # Third-party
@@ -28,6 +29,7 @@ from sematic.db.tests.fixtures import (  # noqa: F401
     run,
     test_db,
 )
+from sematic.log_reader import LogLineResult
 from sematic.scheduling.external_job import JobType
 from sematic.scheduling.kubernetes import KubernetesExternalJob
 from sematic.tests.fixtures import valid_client_version  # noqa: F401
@@ -35,10 +37,17 @@ from sematic.tests.fixtures import valid_client_version  # noqa: F401
 test_list_runs_auth = make_auth_test("/api/v1/runs")
 test_get_run_auth = make_auth_test("/api/v1/runs/123")
 test_get_run_graph_auth = make_auth_test("/api/v1/runs/123/graph")
+test_get_run_logs_graph_auth = make_auth_test("/api/v1/runs/123/logs")
 test_put_run_graph_auth = make_auth_test("/api/v1/graph", method="PUT")
 test_post_events_auth = make_auth_test("/api/v1/events/namespace/event", method="POST")
 test_schedule_run_auth = make_auth_test("/api/v1/runs/123/schedule", method="POST")
 test_future_states_auth = make_auth_test("/api/v1/runs/future_states", method="POST")
+
+
+@pytest.fixture
+def mock_load_log_lines():
+    with mock.patch("sematic.api.endpoints.runs.load_log_lines") as mock_load:
+        yield mock_load
 
 
 @mock_no_auth
@@ -267,6 +276,50 @@ def test_update_future_states(
         assert (
             loaded.exception == "The kubernetes job(s) experienced an unknown failure"
         )
+
+
+@mock_no_auth
+def test_get_run_logs(
+    mock_load_log_lines,
+    persisted_resolution: Resolution,  # noqa: F811
+    persisted_run: Run,  # noqa: F811
+    test_client: flask.testing.FlaskClient,  # noqa: F811
+):
+    mock_result = LogLineResult(
+        more_before=False,
+        more_after=True,
+        lines=["Line 1", "Line 2"],
+        continuation_cursor="abc",
+        log_unavailable_reason=None,
+    )
+    mock_load_log_lines.return_value = mock_result
+    response = test_client.get("/api/v1/runs/{}/logs".format(persisted_run.id))
+
+    payload = response.json
+    payload = typing.cast(typing.Dict[str, typing.Any], payload)
+
+    assert payload["content"] == asdict(mock_result)
+    kwargs = dict(
+        continuation_cursor="continue...",
+        max_lines=10,
+        filter_string="a",
+    )
+
+    response = test_client.get(
+        "/api/v1/runs/{}/logs?{}".format(
+            persisted_run.id, "&".join(f"{k}={v}" for k, v in kwargs.items())
+        ),
+    )
+
+    modified_kwargs = dict(
+        continuation_cursor="continue...",
+        max_lines=10,
+        filter_strings=["a"],
+    )
+    mock_load_log_lines.assert_called_with(
+        run_id=persisted_run.id,
+        **modified_kwargs,
+    )
 
 
 @func

--- a/sematic/log_reader.py
+++ b/sematic/log_reader.py
@@ -1,0 +1,432 @@
+# Standard Library
+import base64
+import itertools
+import json
+from dataclasses import asdict, dataclass
+from typing import Iterable, List, Optional
+
+# Sematic
+from sematic import storage
+from sematic.abstract_future import FutureState
+from sematic.db.models.resolution import Resolution, ResolutionKind, ResolutionStatus
+from sematic.db.queries import get_resolution, get_run
+from sematic.resolvers.cloud_resolver import (
+    END_INLINE_RUN_INDICATOR,
+    START_INLINE_RUN_INDICATOR,
+)
+from sematic.scheduling.external_job import JobType
+
+# Why the "V1"? Because we will likely want to change the structure of
+# the logs such that each file contains a different subset of logs. But
+# when we make this change, we will still want logs written in the old
+# structure to be readable, at least for a while. So we need to identify
+# which structure the files are in somehow, and a v1/v2 prefix is how we
+# can do it.
+V1_LOG_PATH_FORMAT = "logs/v1/run_id/{run_id}/{log_kind}/"
+
+
+def log_prefix(run_id: str, job_type: JobType):
+    return V1_LOG_PATH_FORMAT.format(run_id=run_id, log_kind=job_type.value)
+
+
+@dataclass
+class LogLineResult:
+    """Results of a query for log lines
+
+    Attributes
+    ----------
+    more_before:
+        Are there more lines before the first line returned?
+    more_after:
+        Are there more lines after the last line returned? Will be True
+        if the answer is known to be yes, False if the answer is known to
+        be no. If the answer is not known (i.e. run may still be in
+        progress), True will be returned.
+    lines:
+        The actual log lines
+    continuation_cursor:
+        A string that can be used to continue traversing these logs from where you left
+        off. If more_after is False, this will be set to None.
+    log_unavailable_reason:
+        A human-readable reason why logs are not available.
+    """
+
+    more_before: bool
+    more_after: bool
+    lines: List[str]
+    continuation_cursor: Optional[str]
+    log_unavailable_reason: Optional[str] = None
+
+
+@dataclass
+class Cursor:
+    """A cursor representing a particular place in the process of traversing logs.
+
+    Attributes
+    ----------
+    source_log_key:
+        The storage key for the log that was being used when the search left off. If no
+        logs have been found yet, will be None
+    source_file_line_index:
+        The line number BEFORE filters are applied within the log file being read.
+        It will be the first line that HASN'T yet been read. If no logs have been found,
+        will be -1.
+    filter_strings:
+        The fillter strings that were used for this log traversal.
+    run_id:
+        The run id that was being used for this log traversal.
+    """
+
+    # Why include source log file? Because we will soon likely want to break up
+    # the logs for a single run such that each file contains a *different*
+    # portion of the logs, and we will need to know which file to go to in
+    # order to pick back up. The alternative would be to require
+    # re-traversing already traversed files when continuing.
+    source_log_key: Optional[str]
+    source_file_line_index: int
+    filter_strings: List[str]
+    run_id: str
+
+    def to_token(self) -> str:
+        return str(
+            base64.b64encode(json.dumps(asdict(self)).encode("utf8")), encoding="utf8"
+        )
+
+    @classmethod
+    def from_token(cls, token: str):
+        kwargs = json.loads(
+            base64.b64decode(bytes(token, encoding="utf8")).decode("utf8")
+        )
+        return Cursor(**kwargs)
+
+    @classmethod
+    def nothing_found(cls, filter_strings: List[str], run_id: str):
+        return Cursor(
+            source_log_key=None,
+            source_file_line_index=-1,
+            filter_strings=filter_strings,
+            run_id=run_id,
+        )
+
+
+@dataclass
+class LogLine:
+    source_file: str
+    source_file_index: int
+    line: str
+
+
+def load_log_lines(
+    run_id: str,
+    continuation_cursor: Optional[str],
+    max_lines: int,
+    filter_strings: Optional[List[str]] = None,
+) -> LogLineResult:
+    """Load a portion of the logs for a particular run
+
+    Parameters
+    ----------
+    run_id:
+        The id of the run to get logs for
+    continuation_cursor:
+        A cursor indicating where to continue reading logs from. Should be
+        None if the logs are being read from the beginning.
+    max_lines:
+        The highest number of log lines that should be returned at once
+    filter_strings:
+        Only log lines that contain ALL of the strings in this list will
+        be included in the result
+
+    Returns
+    -------
+    A subset of the logs for the given run
+    """
+    run = get_run(run_id)
+    run_state = FutureState[run.future_state]  # type: ignore
+    still_running = not (run_state.is_terminal() or run_state == FutureState.RAN)
+    resolution = get_resolution(run.root_id)
+    filter_strings = filter_strings if filter_strings is not None else []
+    cursor = (
+        Cursor.from_token(continuation_cursor)
+        if continuation_cursor is not None
+        else Cursor.nothing_found(filter_strings, run_id)
+    )
+    if cursor.run_id != run_id:
+        raise ValueError(
+            f"Tried to continue a log search of {run_id} using a "
+            f"continuation cursor from {cursor.run_id}"
+        )
+    if set(cursor.filter_strings) != set(filter_strings):
+        raise ValueError(
+            f"Tried to continue a log search of {run_id} using a "
+            f"different set of filters than were used in the cursor."
+        )
+
+    if ResolutionStatus[resolution.status] in (  # type: ignore
+        ResolutionStatus.CREATED,
+        ResolutionStatus.SCHEDULED,
+    ):
+        return LogLineResult(
+            more_before=False,
+            more_after=True,
+            lines=[],
+            continuation_cursor=cursor.to_token(),
+            log_unavailable_reason="Resolution has not started yet.",
+        )
+    filter_strings = filter_strings if filter_strings is not None else []
+    if FutureState[run.future_state] == FutureState.CREATED:  # type: ignore
+        return LogLineResult(
+            more_before=False,
+            more_after=True,
+            lines=[],
+            continuation_cursor=cursor.to_token(),
+            log_unavailable_reason="The run has not yet started executing.",
+        )
+    # looking for external jobs to determine inline is only valid
+    # since we know the run has at least reached SCHEDULED due to it
+    # not being CREATED.
+    is_inline = len(run.external_jobs) == 0
+    if is_inline:
+        return _load_inline_logs(
+            run_id=run_id,
+            resolution=resolution,
+            still_running=still_running,
+            cursor_file=cursor.source_log_key,
+            cursor_line_index=cursor.source_file_line_index,
+            max_lines=max_lines,
+            filter_strings=filter_strings,
+        )
+    return _load_non_inline_logs(
+        run_id=run_id,
+        still_running=still_running,
+        cursor_file=cursor.source_log_key,
+        cursor_line_index=cursor.source_file_line_index,
+        max_lines=max_lines,
+        filter_strings=filter_strings,
+    )
+
+
+def _get_latest_log_file(prefix, cursor_file) -> Optional[str]:
+    # recall that for v1 logs, each log file contains ALL the logs from
+    # the beginning of the run until the time that file was uploaded. So
+    # the latest log file contains all the logs we have for the run.
+    log_files = storage.get_child_paths(prefix)
+    if len(log_files) < 1:
+        return None
+
+    # the file wth the highest timestamp has the full logs.
+    if cursor_file is not None and cursor_file not in log_files:
+        raise RuntimeError(
+            f"Trying to continue a log traversal from {cursor_file}, but "
+            f"that file doesn't exist."
+        )
+    latest_log_file = max(
+        log_files,
+        key=lambda path_key: int(
+            path_key.replace(prefix, "").replace(".log", "".replace("/", ""))
+        ),
+    )
+    return latest_log_file
+
+
+def _load_non_inline_logs(
+    run_id: str,
+    still_running: bool,
+    cursor_file: Optional[str],
+    cursor_line_index: int,
+    max_lines: int,
+    filter_strings: List[str],
+) -> LogLineResult:
+    """Load the lines for runs that are NOT inline"""
+    prefix = log_prefix(run_id, JobType.worker)
+    latest_log_file = _get_latest_log_file(prefix, cursor_file)
+    if latest_log_file is None:
+        return LogLineResult(
+            more_before=False,
+            more_after=True,
+            lines=[],
+            continuation_cursor=Cursor.nothing_found(filter_strings, run_id).to_token(),
+            log_unavailable_reason="No log files found",
+        )
+    text_stream = storage.get_line_stream(latest_log_file)
+    line_stream = (
+        LogLine(source_file=latest_log_file, source_file_index=i, line=ln)
+        for i, ln in zip(itertools.count(), text_stream)
+    )
+
+    return get_log_lines_from_line_stream(
+        line_stream=line_stream,
+        still_running=still_running,
+        cursor_source_file=latest_log_file,
+        cursor_line_index=cursor_line_index,
+        max_lines=max_lines,
+        filter_strings=filter_strings,
+        run_id=run_id,
+    )
+
+
+def _load_inline_logs(
+    run_id: str,
+    resolution: Resolution,
+    still_running: bool,
+    cursor_file: Optional[str],
+    cursor_line_index: int,
+    max_lines: int,
+    filter_strings: List[str],
+) -> LogLineResult:
+    """Load the lines for runs that are NOT inline"""
+    if ResolutionKind[resolution.kind] == ResolutionKind.LOCAL:  # type: ignore
+        return LogLineResult(
+            more_before=False,
+            more_after=False,
+            lines=[],
+            continuation_cursor=None,
+            log_unavailable_reason=(
+                "UI logs are only available for runs that "
+                "(a) are executed using the CloudResolver and "
+                "(b) are using the resolver in non-detached mode OR have inline=False."
+            ),
+        )
+    prefix = log_prefix(resolution.root_id, JobType.driver)
+    latest_log_file = _get_latest_log_file(prefix, cursor_file)
+    if latest_log_file is None:
+        return LogLineResult(
+            more_before=False,
+            more_after=True,
+            continuation_cursor=Cursor.nothing_found(filter_strings, run_id).to_token(),
+            lines=[],
+            log_unavailable_reason="Resolver logs are missing",
+        )
+    text_stream: Iterable[str] = storage.get_line_stream(latest_log_file)
+    line_stream = _filter_for_inline(text_stream, run_id, latest_log_file)
+
+    return get_log_lines_from_line_stream(
+        line_stream=line_stream,
+        still_running=still_running,
+        cursor_source_file=cursor_file,
+        cursor_line_index=cursor_line_index,
+        max_lines=max_lines,
+        filter_strings=filter_strings,
+        run_id=run_id,
+    )
+
+
+def _filter_for_inline(
+    text_stream: Iterable[str], run_id: str, source_file: str
+) -> Iterable[LogLine]:
+    """Stream resolver logs to make a new stream with only lines for a particular run"""
+    expected_start = START_INLINE_RUN_INDICATOR.format(run_id)
+    expected_end = END_INLINE_RUN_INDICATOR.format(run_id)
+    buffer_iterator = iter(text_stream)
+    found_start = False
+    file_line_index = 0
+    while True:
+        line = next(buffer_iterator)
+        if expected_start in line:
+            found_start = True
+            continue
+        if not found_start:
+            continue
+        if expected_end in line:
+            break
+        yield LogLine(
+            source_file=source_file, source_file_index=file_line_index, line=line
+        )
+        file_line_index += 1
+
+
+def get_log_lines_from_line_stream(
+    line_stream: Iterable[LogLine],
+    still_running: bool,
+    cursor_source_file: Optional[str],
+    cursor_line_index: int,
+    max_lines: int,
+    filter_strings: List[str],
+    run_id: str,
+) -> LogLineResult:
+    """Given a stream of log lines, produce an object containing the desired subset
+
+    Parameters
+    ----------
+    line_stream:
+        An iterable stream of log lines
+    still_running:
+        A boolean indicating whether the run these logs are for is still running or not
+    cursor_source_file:
+        The source file to continue from. No lines should be returned until this file is
+        reached.
+    cursor_line_index:
+        The source file to continue from. No lines should be returned until this source
+        file index is reached.
+    max_lines:
+        The maximum number of lines that should be returned
+    filter_strings:
+        A list of strings to filter log lines by. Only log lines that contain ALL of the
+        filters will be returned.
+    run_id:
+        The id of the run the traversal is for.
+
+    Returns
+    -------
+    A subset of the logs for the given run
+    """
+    buffer_iterator = iter(line_stream)
+    keep_going = True
+    lines = []
+    has_more = True
+    more_before = False
+    source_file = None
+    source_file_line_index = -1
+    found_cursor = False
+
+    def passes_filter(line: LogLine) -> bool:
+        return all(substring in line.line for substring in filter_strings)
+
+    while keep_going:
+        try:
+            line = next(ln for ln in buffer_iterator)
+            source_file = line.source_file
+            source_file_line_index = line.source_file_index
+
+            if not found_cursor:
+                if (
+                    cursor_source_file is None
+                    or source_file == cursor_source_file
+                    and source_file_line_index >= cursor_line_index
+                ):
+                    found_cursor = True
+                else:
+                    more_before = more_before or passes_filter(line)
+                    continue
+
+            if not passes_filter(line):
+                continue
+
+            lines.append(line.line)
+
+            if len(lines) >= max_lines:
+                has_more = True
+                keep_going = False
+        except StopIteration:
+            keep_going = False
+
+            # hit the end of the logs produced so far. If the run is
+            # done, there are no more logs. Otherwise more might show
+            # up!
+            has_more = still_running
+    missing_reason = None if len(lines) > 0 else "No matching log lines."
+    return LogLineResult(
+        more_before=more_before,
+        more_after=has_more,
+        lines=lines,
+        continuation_cursor=Cursor(
+            source_log_key=source_file,
+            # +1: next time we want to start AFTER where we last read
+            source_file_line_index=source_file_line_index + 1,
+            filter_strings=filter_strings,
+            run_id=run_id,
+        ).to_token()
+        if has_more
+        else None,
+        log_unavailable_reason=missing_reason,
+    )

--- a/sematic/resolvers/BUILD
+++ b/sematic/resolvers/BUILD
@@ -75,6 +75,7 @@ sematic_py_lib(
     deps = [
         ":log_streamer",
         "//sematic:abstract_future",
+        "//sematic:log_reader",
         "//sematic:api_client",
         "//sematic:calculator",
         "//sematic:future",
@@ -83,6 +84,7 @@ sematic_py_lib(
         "//sematic/db/models:factories",
         "//sematic/resolvers:cloud_resolver",
         "//sematic/utils:exceptions",
+        "//sematic/scheduling:external_job",
     ],
     pip_deps = [
         "cloudpickle",

--- a/sematic/resolvers/cloud_resolver.py
+++ b/sematic/resolvers/cloud_resolver.py
@@ -25,6 +25,12 @@ logger = logging.getLogger(__name__)
 _MAX_DELAY_BETWEEN_STATUS_UPDATES_SECONDS = 600  # 600s => 10 min
 _DELAY_BETWEEN_STATUS_UPDATES_BACKOFF = 1.5
 
+# It is important not to change these! They are used for identifying the start/end of
+# inline run logs. If you change it, inline logs written with prior versions of Sematic
+# might not be readable for new versions of Sematic.
+START_INLINE_RUN_INDICATOR = "--------- Sematic Start Inline Run {} ---------"
+END_INLINE_RUN_INDICATOR = "--------- Sematic End Inline Run {} ---------"
+
 
 class CloudResolver(LocalResolver):
     """
@@ -221,6 +227,14 @@ class CloudResolver(LocalResolver):
                 _MAX_DELAY_BETWEEN_STATUS_UPDATES_SECONDS,
                 _DELAY_BETWEEN_STATUS_UPDATES_BACKOFF * delay_between_updates,
             )
+
+    def _start_inline_execution(self, future_id):
+        """Callback called before an inline execution"""
+        logger.info(START_INLINE_RUN_INDICATOR.format(future_id))
+
+    def _end_inline_execution(self, future_id):
+        """Callback called at the end of an inline execution"""
+        logger.info(END_INLINE_RUN_INDICATOR.format(future_id))
 
 
 def make_nested_future_storage_key(future_id: str) -> str:

--- a/sematic/resolvers/log_streamer.py
+++ b/sematic/resolvers/log_streamer.py
@@ -52,8 +52,6 @@ def _stream_logs_to_remote_from_file(
         A callable to perform the upload. It will be given the path to upload from and
         the remote prefix as arguments.
     """
-    if remote_prefix.endswith("/"):
-        remote_prefix = remote_prefix[:-1]
     while True:
         uploader(file_path, remote_prefix)
         time.sleep(upload_interval_seconds)
@@ -71,6 +69,8 @@ def _do_upload(file_path: str, remote_prefix: str):
         The prefix for the remote file. The full remote path will be
         this concatenated with `/<epoch timestamp>.log`.
     """
+    if remote_prefix.endswith("/"):
+        remote_prefix = remote_prefix[:-1]
     remote = f"{remote_prefix}/{int(time.time() * 1000)}.log"
     set_from_file(remote, file_path)
 

--- a/sematic/resolvers/silent_resolver.py
+++ b/sematic/resolvers/silent_resolver.py
@@ -19,10 +19,21 @@ class SilentResolver(StateMachineResolver):
     def _run_inline(self, future: AbstractFuture) -> None:
         self._set_future_state(future, FutureState.SCHEDULED)
         try:
+            self._start_inline_execution(future.id)
             value = future.calculator.calculate(**future.resolved_kwargs)
             self._update_future_with_value(future, value)
         except Exception as exception:
             self._handle_future_failure(future, exception)
+        finally:
+            self._end_inline_execution(future.id)
+
+    def _start_inline_execution(self, future_id):
+        """Callback called before an inline execution"""
+        pass
+
+    def _end_inline_execution(self, future_id):
+        """Callback called at the end of an inline execution"""
+        pass
 
     def _wait_for_scheduled_run(self) -> None:
         pass

--- a/sematic/resolvers/tests/BUILD
+++ b/sematic/resolvers/tests/BUILD
@@ -19,6 +19,7 @@ pytest_test(
     srcs = ["test_log_streamer.py"],
     deps = [
         "//sematic/resolvers:log_streamer",
+        "//sematic/utils:retry",
     ],
 )
 

--- a/sematic/resolvers/worker.py
+++ b/sematic/resolvers/worker.py
@@ -21,11 +21,13 @@ from sematic.db.models.edge import Edge
 from sematic.db.models.factories import get_artifact_value, make_artifact
 from sematic.db.models.run import Run
 from sematic.future import Future
+from sematic.log_reader import log_prefix
 from sematic.resolvers.cloud_resolver import (
     CloudResolver,
     make_nested_future_storage_key,
 )
 from sematic.resolvers.log_streamer import ingested_logs
+from sematic.scheduling.external_job import JobType
 from sematic.utils.exceptions import format_exception_for_run
 
 
@@ -185,10 +187,10 @@ if __name__ == "__main__":
     print("Starting Sematic Worker")
     args = parse_args()
     log_kind = "resolve" if args.resolve else "calculation"
-    log_prefix = f"logs/run_id/{args.run_id}/{log_kind}"
+    prefix = log_prefix(args.run_id, JobType.driver if args.resolve else JobType.worker)
     path = _create_log_file_path("worker.log")
 
-    with ingested_logs(path, log_prefix):
+    with ingested_logs(path, prefix):
         logging.basicConfig(level=logging.INFO)
         logger.info("Worker CLI args: run_id=%s", args.run_id)
         logger.info("Worker CLI args: resolve=%s", args.resolve)

--- a/sematic/storage.py
+++ b/sematic/storage.py
@@ -1,5 +1,6 @@
 # Standard Library
 import io
+from typing import Dict, Iterable, List
 
 # Third-party
 import boto3
@@ -43,10 +44,8 @@ def get(key: str) -> bytes:
 
     See TODO in `set`.
     """
-    s3_client = boto3.client("s3")
-
     file_obj = io.BytesIO()
-
+    s3_client = boto3.client("s3")
     try:
         s3_client.download_fileobj(_get_bucket(), key, file_obj)
     except botocore.exceptions.ClientError as e:
@@ -55,5 +54,71 @@ def get(key: str) -> bytes:
             raise KeyError("{}: {}".format(key, str(e)))
 
         raise e
-
     return file_obj.getvalue()
+
+
+@retry(tries=3, delay=5)
+def get_line_stream(key: str, encoding="utf8") -> Iterable[str]:
+    """Get value from S3 into a stream of text lines.
+
+    The encoding of the
+
+    See TODO in `set`.
+    """
+    s3_client = boto3.client("s3")
+
+    try:
+        obj = s3_client.get_object(Bucket=_get_bucket(), Key=key)
+        return _bytes_buffer_to_text(obj["Body"].iter_lines(), encoding)
+    except botocore.exceptions.ClientError as e:
+        # Standardizing "Not found" errors across storage backends
+        if "404" in str(e):
+            raise KeyError("{}: {}".format(key, str(e)))
+
+        raise e
+
+
+def _bytes_buffer_to_text(bytes_buffer: Iterable[bytes], encoding) -> Iterable[str]:
+    for line in bytes_buffer:
+        yield str(line, encoding=encoding)
+
+
+@retry(tries=3, delay=5)
+def get_child_paths(key_prefix: str) -> List[str]:
+    """Get all descendants of the 'directory' specified by the prefix
+
+    Parameters
+    ----------
+    key_prefix:
+        The prefix to a key that would be used with 'get' or 'set'. The keys are
+        treated as being like directories, with '/' in a key specifying an
+        organizational unit for the objects.
+
+    Returns
+    -------
+    A list of all keys that start with the prefix. You can think of this as getting
+    the absolute file paths for all contents of a directory (including 'files' in
+    'subdirectories').
+    """
+    if not key_prefix.endswith("/"):
+        key_prefix = f"{key_prefix}/"
+    s3_client = boto3.client("s3")
+    keys = []
+    has_more = True
+    continuation_token = None
+    while has_more:
+        continuation: Dict[str, str] = (
+            {}
+            if continuation_token is None
+            else {"ContinuationToken": continuation_token}  # type: ignore
+        )
+        list_objects_return = s3_client.list_objects_v2(
+            Bucket=_get_bucket(),
+            Prefix=key_prefix,
+            **continuation,
+        )
+        has_more = list_objects_return["IsTruncated"]
+        continuation_token = list_objects_return.get("NextContinuationToken")
+        for obj in list_objects_return.get("Contents", []):
+            keys.append(obj["Key"])
+    return keys

--- a/sematic/tests/BUILD
+++ b/sematic/tests/BUILD
@@ -74,6 +74,21 @@ pytest_test(
 )
 
 pytest_test(
+    name = "test_log_reader",
+    srcs = ["test_log_reader.py"],
+    deps = [
+        "//sematic:abstract_future",
+        "//sematic:log_reader",
+        "//sematic:storage",
+        "//sematic/db:queries",
+        "//sematic/tests:fixtures",
+        "//sematic/db/tests:fixtures",
+        "//sematic/resolvers:cloud_resolver",
+        "//sematic/scheduling:external_job",
+    ],
+)
+
+pytest_test(
     name = "test_user_settings",
     srcs = ["test_user_settings.py"],
     deps = [

--- a/sematic/tests/fixtures.py
+++ b/sematic/tests/fixtures.py
@@ -16,6 +16,8 @@ def test_storage():
     current_set = storage.set
     current_get = storage.get
     current_set_from_file = storage.set_from_file
+    current_get_line_stream = storage.get_line_stream
+    current_get_child_paths = storage.get_child_paths
 
     store = {}
 
@@ -29,9 +31,22 @@ def test_storage():
         with open(file_path, "rb") as fp:
             store[key] = b"".join(fp)
 
+    def _get_line_stream(key):
+        as_bytes = _get(key)
+        as_str = str(as_bytes, encoding="utf8")
+        for line in as_str.split("\n"):
+            yield line
+
+    def _get_child_paths(key_prefix):
+        if not key_prefix.endswith("/"):
+            key_prefix = f"{key_prefix}/"
+        return [key for key in store.keys() if key.startswith(key_prefix)]
+
     storage.set = _set
     storage.get = _get
     storage.set_from_file = _set_from_file
+    storage.get_line_stream = _get_line_stream
+    storage.get_child_paths = _get_child_paths
 
     try:
         yield store
@@ -39,6 +54,8 @@ def test_storage():
         storage.set = current_set
         storage.get = current_get
         storage.set_from_file = current_set_from_file
+        storage.get_line_stream = current_get_line_stream
+        storage.get_child_paths = current_get_child_paths
 
 
 @pytest.fixture

--- a/sematic/tests/test_log_reader.py
+++ b/sematic/tests/test_log_reader.py
@@ -1,0 +1,473 @@
+# Standard Library
+from typing import Iterable, List
+
+# Sematic
+from sematic import storage
+from sematic.abstract_future import FutureState
+from sematic.db.models.resolution import ResolutionStatus
+from sematic.db.queries import save_resolution, save_run
+from sematic.db.tests.fixtures import make_resolution, make_run, test_db  # noqa: F401
+from sematic.log_reader import (
+    Cursor,
+    LogLine,
+    LogLineResult,
+    _load_inline_logs,
+    _load_non_inline_logs,
+    get_log_lines_from_line_stream,
+    load_log_lines,
+    log_prefix,
+)
+from sematic.resolvers.cloud_resolver import (
+    END_INLINE_RUN_INDICATOR,
+    START_INLINE_RUN_INDICATOR,
+)
+from sematic.scheduling.external_job import ExternalJob, JobType
+from sematic.tests.fixtures import test_storage  # noqa: F401
+
+_streamed_lines: List[str] = []
+_DUMMY_LOGS_FILE = "logs.log"
+_DUMMY_RUN_ID = "abc123"
+
+
+# Using this should help ensure we're actually properly streaming.
+# If anything is attempting to put the whole stream in memory this
+# will blow up
+def infinite_logs() -> Iterable[LogLine]:
+    count = 0
+    while True:
+        line = f"Line {count}"
+        yield LogLine(source_file=_DUMMY_LOGS_FILE, source_file_index=count, line=line)
+        count += 1
+
+
+def finite_logs(n_lines: int) -> Iterable[LogLine]:
+    return (
+        LogLine(source_file=_DUMMY_LOGS_FILE, source_file_index=i, line=f"Line {i}")
+        for i in range(n_lines)
+    )
+
+
+def fake_streamer(to_stream: Iterable[LogLine]) -> Iterable[LogLine]:
+    for line in to_stream:
+        _streamed_lines.append(line.line)
+        yield line
+
+
+def test_get_log_lines_from_line_stream_does_streaming():
+    _streamed_lines.clear()
+    max_lines = 200
+    result = get_log_lines_from_line_stream(
+        line_stream=fake_streamer(infinite_logs()),
+        still_running=True,
+        cursor_source_file=None,
+        cursor_line_index=-1,
+        max_lines=max_lines,
+        filter_strings=[],
+        run_id=_DUMMY_RUN_ID,
+    )
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=False,
+        more_after=True,
+        lines=[f"Line {i}" for i in range(max_lines)],
+        log_unavailable_reason=None,
+    )
+    assert _streamed_lines == result.lines
+
+    # emulate continuation
+    result = get_log_lines_from_line_stream(
+        line_stream=infinite_logs(),
+        still_running=True,
+        cursor_source_file=cursor.source_log_key,
+        cursor_line_index=cursor.source_file_line_index,
+        max_lines=max_lines,
+        filter_strings=[],
+        run_id=_DUMMY_RUN_ID,
+    )
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=True,
+        lines=[f"Line {i}" for i in range(max_lines, 2 * max_lines)],
+        log_unavailable_reason=None,
+    )
+
+
+def test_get_log_lines_from_line_stream_more_after():
+    max_lines = 200
+    kwargs = dict(
+        cursor_source_file=None,
+        cursor_line_index=-1,
+        max_lines=max_lines,
+        filter_strings=[],
+        run_id=_DUMMY_RUN_ID,
+    )
+    result = get_log_lines_from_line_stream(
+        line_stream=infinite_logs(),
+        still_running=True,
+        **kwargs,
+    )
+    assert result.more_after
+
+    result = get_log_lines_from_line_stream(
+        line_stream=finite_logs(max_lines - 1),
+        still_running=True,
+        **kwargs,
+    )
+    assert result.more_after
+
+    result = get_log_lines_from_line_stream(
+        line_stream=finite_logs(max_lines - 1),
+        still_running=False,
+        **kwargs,
+    )
+    assert not result.more_after
+
+
+def test_get_log_lines_from_line_stream_filter():
+    max_lines = 10
+    result = get_log_lines_from_line_stream(
+        line_stream=fake_streamer(infinite_logs()),
+        still_running=True,
+        cursor_source_file=None,
+        cursor_line_index=-1,
+        run_id=_DUMMY_RUN_ID,
+        max_lines=max_lines,
+        filter_strings=["2"],
+    )
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=False,
+        more_after=True,
+        lines=[
+            "Line 2",
+            "Line 12",
+            "Line 20",
+            "Line 21",
+            "Line 22",
+            "Line 23",
+            "Line 24",
+            "Line 25",
+            "Line 26",
+            "Line 27",
+        ],
+        log_unavailable_reason=None,
+    )
+
+    result = get_log_lines_from_line_stream(
+        line_stream=fake_streamer(infinite_logs()),
+        still_running=True,
+        cursor_source_file=cursor.source_log_key,
+        cursor_line_index=cursor.source_file_line_index,
+        run_id=_DUMMY_RUN_ID,
+        max_lines=max_lines,
+        filter_strings=["2"],
+    )
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=True,
+        lines=[
+            "Line 28",
+            "Line 29",
+            "Line 32",
+            "Line 42",
+            "Line 52",
+            "Line 62",
+            "Line 72",
+            "Line 82",
+            "Line 92",
+            "Line 102",
+        ],
+        log_unavailable_reason=None,
+    )
+
+
+def test_load_non_inline_logs(test_storage, test_db):  # noqa: F811
+    run = make_run(future_state=FutureState.RESOLVED)
+    save_run(run)
+
+    max_lines = 50
+    text_lines = [line.line for line in finite_logs(100)]
+    log_file_contents = bytes("\n".join(text_lines), encoding="utf8")
+    prefix = log_prefix(run.id, JobType.worker)
+    key = f"{prefix}12345.log"
+
+    result = _load_non_inline_logs(
+        run_id=run.id,
+        still_running=False,
+        cursor_file=None,
+        cursor_line_index=-1,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    assert result.more_after
+    assert result.lines == []
+    assert result.continuation_cursor is not None
+    assert result.log_unavailable_reason == "No log files found"
+    storage.set(key, log_file_contents)
+
+    result = _load_non_inline_logs(
+        run_id=run.id,
+        still_running=False,
+        cursor_file=None,
+        cursor_line_index=-1,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=False,
+        more_after=True,
+        lines=text_lines[:max_lines],
+        log_unavailable_reason=None,
+    )
+
+    result = _load_non_inline_logs(
+        run_id=run.id,
+        still_running=False,
+        cursor_file=cursor.source_log_key,
+        cursor_line_index=cursor.source_file_line_index,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=True,
+        lines=text_lines[max_lines : 2 * max_lines],  # noqa: E203
+        log_unavailable_reason=None,
+    )
+
+    result = _load_non_inline_logs(
+        run_id=run.id,
+        still_running=False,
+        cursor_file=cursor.source_log_key,
+        cursor_line_index=cursor.source_file_line_index,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=False,
+        lines=[],
+        log_unavailable_reason="No matching log lines.",
+    )
+
+
+def test_load_inline_logs(test_storage, test_db):  # noqa: F811
+    run = make_run(future_state=FutureState.RESOLVED)
+    save_run(run)
+    resolution = make_resolution(status=ResolutionStatus.COMPLETE)
+    resolution.root_id = run.root_id
+
+    run_text_lines = [line.line for line in finite_logs(100)]
+    resolver_lines = ["blah", "blah", "blah"]
+    text_lines = (
+        resolver_lines
+        + [START_INLINE_RUN_INDICATOR.format(run.id)]
+        + run_text_lines
+        + [END_INLINE_RUN_INDICATOR.format(run.id)]
+        + resolver_lines
+    )
+    max_lines = 50
+
+    log_file_contents = bytes("\n".join(text_lines), encoding="utf8")
+    prefix = log_prefix(resolution.root_id, JobType.driver)
+    key = f"{prefix}12345.log"
+
+    result = _load_inline_logs(
+        run_id=run.id,
+        resolution=resolution,
+        still_running=False,
+        cursor_file=None,
+        cursor_line_index=-1,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    assert result.more_after
+    assert result.lines == []
+    assert result.continuation_cursor is not None
+    assert result.log_unavailable_reason == "Resolver logs are missing"
+    storage.set(key, log_file_contents)
+
+    result = _load_inline_logs(
+        run_id=run.id,
+        resolution=resolution,
+        still_running=False,
+        cursor_file=None,
+        cursor_line_index=-1,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=False,
+        more_after=True,
+        lines=run_text_lines[:max_lines],
+        log_unavailable_reason=None,
+    )
+
+    result = _load_inline_logs(
+        run_id=run.id,
+        resolution=resolution,
+        still_running=False,
+        cursor_file=cursor.source_log_key,
+        cursor_line_index=cursor.source_file_line_index,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    cursor = Cursor.from_token(result.continuation_cursor)
+    result.continuation_cursor = None
+
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=True,
+        lines=run_text_lines[max_lines:],
+        log_unavailable_reason=None,
+    )
+
+    result = _load_inline_logs(
+        run_id=run.id,
+        resolution=resolution,
+        still_running=False,
+        cursor_file=cursor.source_log_key,
+        cursor_line_index=cursor.source_file_line_index,
+        max_lines=max_lines,
+        filter_strings=[],
+    )
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=False,
+        lines=[],
+        log_unavailable_reason="No matching log lines.",
+    )
+
+
+def test_load_log_lines(test_storage, test_db):  # noqa: F811
+    run = make_run(future_state=FutureState.CREATED)
+    save_run(run)
+    resolution = make_resolution(status=ResolutionStatus.SCHEDULED)
+    resolution.root_id = run.root_id
+    save_resolution(resolution)
+    max_lines = 50
+
+    result = load_log_lines(
+        run_id=run.id,
+        continuation_cursor=None,
+        max_lines=max_lines,
+    )
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=False,
+        more_after=True,
+        lines=[],
+        log_unavailable_reason="Resolution has not started yet.",
+    )
+
+    resolution.status = ResolutionStatus.RUNNING
+    save_resolution(resolution)
+
+    result = load_log_lines(
+        run_id=run.id,
+        continuation_cursor=None,
+        max_lines=max_lines,
+    )
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=False,
+        more_after=True,
+        lines=[],
+        log_unavailable_reason="The run has not yet started executing.",
+    )
+
+    run.future_state = FutureState.SCHEDULED
+    run.external_jobs = [ExternalJob(kind="fake", try_number=0, external_job_id="fake")]
+    save_run(run)
+    text_lines = [line.line for line in finite_logs(100)]
+    log_file_contents = bytes("\n".join(text_lines), encoding="utf8")
+    prefix = log_prefix(run.id, JobType.worker)
+    key = f"{prefix}12345.log"
+    storage.set(key, log_file_contents)
+
+    result = load_log_lines(
+        run_id=run.id,
+        continuation_cursor=None,
+        max_lines=max_lines,
+    )
+    token = result.continuation_cursor
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=False,
+        more_after=True,
+        lines=text_lines[:max_lines],
+        log_unavailable_reason=None,
+    )
+
+    result = load_log_lines(
+        run_id=run.id,
+        continuation_cursor=token,
+        max_lines=max_lines,
+    )
+    token = result.continuation_cursor
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=True,
+        lines=text_lines[max_lines : 2 * max_lines],  # noqa: E203
+        log_unavailable_reason=None,
+    )
+
+    result = load_log_lines(
+        run_id=run.id,
+        continuation_cursor=token,
+        max_lines=max_lines,
+    )
+    token = result.continuation_cursor
+    result.continuation_cursor = None
+    assert result == LogLineResult(
+        continuation_cursor=None,
+        more_before=True,
+        more_after=True,
+        lines=[],
+        log_unavailable_reason="No matching log lines.",
+    )
+
+    result = load_log_lines(
+        run_id=run.id, continuation_cursor=None, max_lines=1, filter_strings=["2", "4"]
+    )
+    assert result.lines == ["Line 24"]
+
+    result = load_log_lines(
+        run_id=run.id,
+        continuation_cursor=result.continuation_cursor,
+        max_lines=1,
+        filter_strings=["2", "4"],
+    )
+    assert result.lines == ["Line 42"]


### PR DESCRIPTION
Ideally we want to minimize the number of bazel setup steps users have to leverage Sematic's bazel rules. This PR eliminates the need for multirun, while still providing the ability to combine image pushing and launch script execution in one command.

Tested against our example bazel repo, including command line arg usage, and `_local` target.